### PR TITLE
fix: return something during loading

### DIFF
--- a/src/Components/Product.js
+++ b/src/Components/Product.js
@@ -5,6 +5,7 @@ import {graphCmsImageUrl} from '../lib'
 
 const Product = ({data:{loading,error,product}}) =>{
   if(error) return <div>Error</div>
+  if (loading) return <div>Loading ...</div>
   if(!loading) return (
     <article>
         <h1>{product.name}</h1>


### PR DESCRIPTION
You always need to return something (or at least null) from a component